### PR TITLE
Replace references to universe.serv.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The repository provides a web application for browsing the DC/OS Universe packag
 
 ## Using
 
-You can find the deployed application at [https://universe.serv.sh](https://universe.serv.sh), install it locally, or use the [dcoslabs/dcos-universe-browser](https://hub.docker.com/r/dcoslabs/dcos-universe-browser/) Docker image.
+You can find the deployed application at [https://universe.dcos.io](https://universe.dcos.io), install it locally, or use the [dcoslabs/dcos-universe-browser](https://hub.docker.com/r/dcoslabs/dcos-universe-browser/) Docker image.
 
 ## Installation
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt for http://universe.serv.sh/
+# robots.txt for http://universe.dcos.io/
 
 User-agent: *
 


### PR DESCRIPTION
The new canonical address for this services is http://universe.dcos.io so we
want to be using that instead.