### PR TITLE
Revert "Update javascript to pick up 1.10 examples"

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -103,11 +103,8 @@ function fillExamples() {
             var baseUrl = "https://raw.githubusercontent.com/dcos/examples/master/" + packageName + "/";
             // Example version
             var exampleVersion = null;
-            // Check if 1.10 example exists
-            if (fs.existsSync(dcosExamplesFolder + "/" + packageName + "/1.10/README.md")) {
-                exampleVersion = "1.10";
             // Check if 1.9 example exists
-            } else if (fs.existsSync(dcosExamplesFolder + "/" + packageName + "/1.9/README.md")) {
+            if (fs.existsSync(dcosExamplesFolder + "/" + packageName + "/1.9/README.md")) {
                 exampleVersion = "1.9";
             } else if (fs.existsSync(dcosExamplesFolder + "/" + packageName + "/1.8/README.md")) {
                 exampleVersion = "1.8";


### PR DESCRIPTION
Reverts dcos-labs/dcos-universe-browser#13

Accepting Tobi's much better change instead and re-releasing as a new version.