### PR TITLE
Add legal disclaimer

### DIFF
--- a/public/partials/package.html
+++ b/public/partials/package.html
@@ -111,6 +111,13 @@
                             <a ng-href="{{license.url}}" target="_blank"><span class="label label-info">{{packageInfo.licenses[$index].name}}</span></a>
                         </span>
                     </div>
+                <div class="row spacer" style="margin-top: 50px;">
+                    <div class="col-sm-12">
+                        <span>
+                            <a>The software listed above is solely subject to the license(s) listed here, as between you and the creator of the software. Mesosphere is not responsible for, and disclaims any indemnification, warranty of any kind either express or implied, or (unless described in a mutually executed written support agreement) support, with respect to the software listed here.</a>
+                        </span>
+                    </div>
+                </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
As requested by Mesosphere legal counsel, add a disclaimer to the bottom of each package listing. 